### PR TITLE
set lower minimum num shards

### DIFF
--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -203,7 +203,7 @@ class HailElasticSearchTask(luigi.Task):
     es_index = luigi.Parameter(description='ElasticSearch index.', default='data')
     es_username = luigi.Parameter(description='ElasticSearch username.', default='pipeline')
     es_password = luigi.Parameter(description='ElasticSearch password.', visibility=ParameterVisibility.PRIVATE, default=None)
-    es_index_min_num_shards = luigi.IntParameter(default=6,
+    es_index_min_num_shards = luigi.IntParameter(default=1,
                                                  description='Number of shards for the index will be the greater of '
                                                              'this value and a calculated value based on the matrix.')
 

--- a/sv_pipeline/exome/load_data.py
+++ b/sv_pipeline/exome/load_data.py
@@ -405,7 +405,7 @@ def main():
     p.add_argument('--sample-type', default='WES')
     p.add_argument('--es-host', default='localhost')
     p.add_argument('--es-port', default='9200')
-    p.add_argument('--num-shards', default=6)
+    p.add_argument('--num-shards', default=1)
 
     args = p.parse_args()
 

--- a/sv_pipeline/exome/load_data.py
+++ b/sv_pipeline/exome/load_data.py
@@ -346,7 +346,7 @@ def get_es_schema(all_fields, nested_fields):
     return schema
 
 
-def export_to_elasticsearch(es_host, es_port, rows, index_name, meta, es_password, num_shards=6):
+def export_to_elasticsearch(es_host, es_port, rows, index_name, meta, es_password, num_shards=1):
     """
     Export SV data to elasticsearch
 

--- a/sv_pipeline/genome/load_data.py
+++ b/sv_pipeline/genome/load_data.py
@@ -186,7 +186,7 @@ def main():
     p.add_argument('--gencode-path', help='path for downloaded Gencode data')
     p.add_argument('--es-host', default='localhost')
     p.add_argument('--es-port', default='9200')
-    p.add_argument('--num-shards', type=int, default=6)
+    p.add_argument('--num-shards', type=int, default=1)
     p.add_argument('--block-size', type=int, default=2000)
 
     args = p.parse_args()

--- a/sv_pipeline/genome/load_data_tests.py
+++ b/sv_pipeline/genome/load_data_tests.py
@@ -299,7 +299,7 @@ class LoadDataTest(unittest.TestCase):
         mock_load_mt.assert_called_with(self.vcf_file, None, False)
         mock_subset.assert_called_with(TEST_GUID, self.mt, skip_sample_subset=False, ignore_missing_samples=False)
         mock_annot.assert_called_with(mt, 29, None)
-        mock_export.assert_called_with(annotated_rows, self.vcf_file, TEST_GUID, 'localhost', '9200', 2000, 6)
+        mock_export.assert_called_with(annotated_rows, self.vcf_file, TEST_GUID, 'localhost', '9200', 2000, 1)
 
         # test arguments with non-default values
         mock_hl.reset_mock()


### PR DESCRIPTION
small shards create a huge memory overhead and minor search performance decrease, so if data fits in one shard we should do that