### PR TITLE
Add 'nodes.wan.only' parameter to export_table_to_elasticsearch()

### DIFF
--- a/hail_scripts/v02/utils/elasticsearch_client.py
+++ b/hail_scripts/v02/utils/elasticsearch_client.py
@@ -42,6 +42,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
         export_globals_to_index_meta=True,
         verbose=True,
         write_null_values=False,
+        elasticsearch_config={},
     ):
         """Create a new elasticsearch index to store the records in this table, and then export all records to it.
 
@@ -88,12 +89,11 @@ class ElasticsearchClient(BaseElasticsearchClient):
             func_to_run_after_index_exists (function): optional function to run after creating the index, but before exporting any data.
             export_globals_to_index_meta (bool): whether to add table.globals object to the index _meta field:
                 (see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html)
-            child_table (Table): if not None, records in this Table will be exported as children of records in the main Table.
             verbose (bool): whether to print schema and stats
             write_null_values (bool): whether to write fields that are null to the index
+            elasticsearch_config: The initial elasticsearch config from the caller
         """
 
-        elasticsearch_config = {}
         if (
             elasticsearch_write_operation is not None
             and elasticsearch_write_operation not in ELASTICSEARCH_WRITE_OPERATIONS

--- a/hail_scripts/v02/utils/elasticsearch_client.py
+++ b/hail_scripts/v02/utils/elasticsearch_client.py
@@ -42,7 +42,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
         export_globals_to_index_meta=True,
         verbose=True,
         write_null_values=False,
-        elasticsearch_config={},
+        elasticsearch_config=None,
     ):
         """Create a new elasticsearch index to store the records in this table, and then export all records to it.
 
@@ -94,6 +94,7 @@ class ElasticsearchClient(BaseElasticsearchClient):
             elasticsearch_config: The initial elasticsearch config from the caller
         """
 
+        elasticsearch_config = elasticsearch_config or {}
         if (
             elasticsearch_write_operation is not None
             and elasticsearch_write_operation not in ELASTICSEARCH_WRITE_OPERATIONS

--- a/sv_pipeline/genome/load_data.py
+++ b/sv_pipeline/genome/load_data.py
@@ -189,7 +189,7 @@ def main():
     p.add_argument('--es-port', default='9200')
     p.add_argument('--num-shards', type=int, default=1)
     p.add_argument('--block-size', type=int, default=2000)
-    p.add_argument('--es-nodes-wan-only', default='false')
+    p.add_argument('--es-nodes-wan-only', action='store_true')
 
     args = p.parse_args()
 
@@ -204,7 +204,7 @@ def main():
     rows = annotate_fields(mt, args.gencode_release, args.gencode_path)
 
     export_to_es(rows, args.input_dataset, args.project_guid, args.es_host, args.es_port, args.block_size,
-                 args.num_shards, args.es_nodes_wan_only)
+                 args.num_shards, 'true' if args.es_nodes_wan_only else 'false')
     logger.info('Total time for subsetting, annotating, and exporting: {}'.format(time.time() - start_time))
 
     hl.stop()


### PR DESCRIPTION
When the ES is running in a docker container, it could incorrectly get the internal container IP for the address of the ES node rather than the one that can be accessed externally. Add 'nodes.wan.only' can solve the problem. See [the reference](https://discuss.elastic.co/t/get-org-elasticsearch-hadoop-rest-eshadoopnonodesleftexception-connection-error-check-network-and-or-proxy-settings-all-nodes-failed-tried/79509).