### PR TITLE
Add cleanup step to  wait for shard transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changes
+
+* Added function `wait_for_loading_shards_transfer` [(#261)](https://github.com/broadinstitute/hail-elasticsearch-pipelines/pull/260)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Changes
 
-* Added function `wait_for_loading_shards_transfer` [(#261)](https://github.com/broadinstitute/hail-elasticsearch-pipelines/pull/260)
+* Added function `wait_for_loading_shards_transfer` to luigi SNV pipeline [(#261)](https://github.com/broadinstitute/hail-elasticsearch-pipelines/pull/261)

--- a/hail_scripts/shared/elasticsearch_client_v7.py
+++ b/hail_scripts/shared/elasticsearch_client_v7.py
@@ -131,7 +131,7 @@ class ElasticsearchClient:
         mappings = self.es.indices.get_mapping(index=index_name)
         return mappings.get(index_name, {}).get('mappings', {}).get('_meta', {})
 
-    def wait_for_loading_shards_transfer(self, index_name, num_attempts=1000):
+    def wait_for_shard_transfer(self, index_name, num_attempts=1000):
         """
         Wait for shards to move off of the loading nodes before connecting to seqr 
         """

--- a/hail_scripts/shared/elasticsearch_client_v7.py
+++ b/hail_scripts/shared/elasticsearch_client_v7.py
@@ -139,7 +139,7 @@ class ElasticsearchClient:
         if "r0384_rare_genomes_project_gen" not in index_name:
             for i in range(num_attempts):
                 shards = self.es.cat.shards(index=index_name)
-                if "es-data-loading" not in shards:
+                if LOADING_NODES_NAME not in shards:
                     logger.warning("Shards are on {}".format(shards))
                     return
                 logger.warning("Waiting for {} shards to transfer off the es-data-loading nodes: \n{}".format(

--- a/hail_scripts/shared/elasticsearch_client_v7.py
+++ b/hail_scripts/shared/elasticsearch_client_v7.py
@@ -140,8 +140,9 @@ class ElasticsearchClient:
             for i in range(num_attempts):
                 shards = self.es.cat.shards(index=index_name)
                 if "es-data-loading" not in shards:
+                    logger.warning("Shards are on {}".format(shards))
                     return
-                logger.info("Waiting for {} shards to transfer off the es-data-loading nodes: \n{}".format(
+                logger.warning("Waiting for {} shards to transfer off the es-data-loading nodes: \n{}".format(
                     len(shards.strip().split("\n")), shards))
                 time.sleep(5)
 

--- a/hail_scripts/shared/elasticsearch_client_v7.py
+++ b/hail_scripts/shared/elasticsearch_client_v7.py
@@ -135,17 +135,13 @@ class ElasticsearchClient:
         """
         Wait for shards to move off of the loading nodes before connecting to seqr 
         """
-        # RGP is too large and will not transfer until old index is deleted
-        if "r0384_rare_genomes_project_gen" not in index_name:
-            for i in range(num_attempts):
-                shards = self.es.cat.shards(index=index_name)
-                if LOADING_NODES_NAME not in shards:
-                    logger.warning("Shards are on {}".format(shards))
-                    return
-                logger.warning("Waiting for {} shards to transfer off the es-data-loading nodes: \n{}".format(
-                    len(shards.strip().split("\n")), shards))
-                time.sleep(5)
+        for i in range(num_attempts):
+            shards = self.es.cat.shards(index=index_name)
+            if LOADING_NODES_NAME not in shards:
+                logger.warning("Shards are on {}".format(shards))
+                return
+            logger.warning("Waiting for {} shards to transfer off the es-data-loading nodes: \n{}".format(
+                len(shards.strip().split("\n")), shards))
+            time.sleep(5)
 
-            raise Exception('Shards did not transfer off loading nodes')
-        else:
-            logger.info("Will not wait for RGP shards to transfer off the es-data-loading nodes")
+        raise Exception('Shards did not transfer off loading nodes')

--- a/hail_scripts/shared/elasticsearch_client_v7.py
+++ b/hail_scripts/shared/elasticsearch_client_v7.py
@@ -132,7 +132,10 @@ class ElasticsearchClient:
         return mappings.get(index_name, {}).get('mappings', {}).get('_meta', {})
 
     def wait_for_loading_shards_transfer(self, index_name, num_attempts=1000):
-        # RGP is too large and needs to remain on data nodes until old index is deleted
+        """
+        Wait for shards to move off of the loading nodes before connecting to seqr 
+        """
+        # RGP is too large and will not transfer until old index is deleted
         if "r0384_rare_genomes_project_gen" not in index_name:
             for i in range(num_attempts):
                 shards = self.es.cat.shards(index=index_name)

--- a/hail_scripts/shared/elasticsearch_client_v7.py
+++ b/hail_scripts/shared/elasticsearch_client_v7.py
@@ -130,3 +130,18 @@ class ElasticsearchClient:
     def get_index_meta(self, index_name):
         mappings = self.es.indices.get_mapping(index=index_name)
         return mappings.get(index_name, {}).get('mappings', {}).get('_meta', {})
+
+    def wait_for_loading_shards_transfer(self, index_name, num_attempts=1000):
+        # RGP is too large and needs to remain on data nodes until old index is deleted
+        if "r0384_rare_genomes_project_gen" not in index_name:
+            for i in range(num_attempts):
+                shards = self.es.cat.shards(index=index_name)
+                if "es-data-loading" not in shards:
+                    return
+                logger.info("Waiting for {} shards to transfer off the es-data-loading nodes: \n{}".format(
+                    len(shards.strip().split("\n")), shards))
+                time.sleep(5)
+
+            raise Exception('Shards did not transfer off loading nodes')
+        else:
+            logger.info("Will not wait for RGP shards to transfer off the es-data-loading nodes")

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -235,9 +235,11 @@ class HailElasticSearchTask(luigi.Task):
                                                num_shards=num_shards,
                                                write_null_values=True)
 
-    def cleanup(self):
+    def cleanup(self, es_shards):
         self._es.route_index_off_temp_es_cluster(self.es_index)
-        self._es.wait_for_shard_transfer(self.es_index)
+        # Current disk configuration requires the previous index to be deleted prior to large indices, ~1TB, transferring off loading nodes
+        if es_shards < 25:
+            self._es.wait_for_shard_transfer(self.es_index)
 
 
     def _mt_num_shards(self, mt):

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -237,7 +237,7 @@ class HailElasticSearchTask(luigi.Task):
 
     def cleanup(self):
         self._es.route_index_off_temp_es_cluster(self.es_index)
-        self._es.wait_for_loading_shards_transfer(self.es_index)
+        self._es.wait_for_shard_transfer(self.es_index)
 
 
     def _mt_num_shards(self, mt):

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -237,6 +237,7 @@ class HailElasticSearchTask(luigi.Task):
 
     def cleanup(self):
         self._es.route_index_off_temp_es_cluster(self.es_index)
+        self._es.wait_for_loading_shards_transfer(self.es_index)
 
 
     def _mt_num_shards(self, mt):

--- a/luigi_pipeline/seqr_loading.py
+++ b/luigi_pipeline/seqr_loading.py
@@ -198,12 +198,13 @@ class SeqrMTToESTask(HailElasticSearchTask):
     def run(self):
         mt = self.import_mt()
         row_table = SeqrVariantsAndGenotypesSchema.elasticsearch_row(mt)
-        self.export_table_to_elasticsearch(row_table, self._mt_num_shards(mt))
+        es_shards = self._mt_num_shards(mt)
+        self.export_table_to_elasticsearch(row_table, es_shards)
 
         with hl.hadoop_open(self.completed_marker_path, "w") as f:
             f.write(".")
 
-        self.cleanup()
+        self.cleanup(es_shards)
 
 
 if __name__ == '__main__':

--- a/luigi_pipeline/seqr_loading_optimized.py
+++ b/luigi_pipeline/seqr_loading_optimized.py
@@ -61,9 +61,10 @@ class SeqrMTToESOptimizedTask(HailElasticSearchTask):
         row_ht = genotypes_mt.rows().join(variants_mt.rows())
 
         row_ht = SeqrVariantsAndGenotypesSchema.elasticsearch_row(row_ht)
-        self.export_table_to_elasticsearch(row_ht, self._mt_num_shards(genotypes_mt))
-
-        self.cleanup()
+        es_shards = self._mt_num_shards(genotypes_mt)
+        self.export_table_to_elasticsearch(row_ht, es_shards)
+        
+        self.cleanup(es_shards)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a waiting step for the shard transfer for all projects except RGP. Not hardcoding this bit is probably ideal but I was trying to take the manual step out of the airflow config. The code was based off of v01 but I changed the logger.info to logger.warning because we recently changed Airflow's logging config to warn. I debated increasing the wait time to 10 but stuck with 5 in the end. Happy to change if there are strong opinions. I tested this with this pipeline version: gs://seqr-luigi/releases/optimized-v1.4.5.test/ and the dataproc job is here: https://console.cloud.google.com/dataproc/jobs/pyspark_export_project_R0449_pathways_mgh_20210723_01d8d1ec?region=global&authuser=0&project=seqr-project 

This also adds a changelog to the repo. 