### PR TITLE
Added id-file command line argument to overwrite the built-in id file path

### DIFF
--- a/sv_pipeline/genome/load_data.py
+++ b/sv_pipeline/genome/load_data.py
@@ -102,9 +102,9 @@ def load_mt(input_dataset, matrixtable_file, overwrite_matrixtable):
     return hl.read_matrix_table(matrixtable_file)
 
 
-def subset_mt(project_guid, mt, skip_sample_subset=False, ignore_missing_samples=False):
+def subset_mt(project_guid, mt, skip_sample_subset=False, ignore_missing_samples=False, id_file=None):
     if not skip_sample_subset:
-        sample_subset = get_sample_subset(project_guid, WGS_SAMPLE_TYPE)
+        sample_subset = get_sample_subset(project_guid, WGS_SAMPLE_TYPE, filename=id_file)
         found_samples = sample_subset.intersection(mt.aggregate_cols(hl.agg.collect_as_set(mt.s)))
         if len(found_samples) != len(sample_subset):
             missed_samples = sample_subset - found_samples
@@ -205,6 +205,7 @@ def main():
     p.add_argument('--num-shards', type=int, default=1)
     p.add_argument('--block-size', type=int, default=2000)
     p.add_argument('--es-nodes-wan-only', action='store_true')
+    p.add_argument('--id-file', help='The full path (can start with gs://) of the id file.')
 
     args = p.parse_args()
 
@@ -214,7 +215,9 @@ def main():
 
     mt = load_mt(args.input_dataset, args.matrixtable_file, args.overwrite_matrixtable)
 
-    mt = subset_mt(args.project_guid, mt, skip_sample_subset=args.skip_sample_subset, ignore_missing_samples=args.ignore_missing_samples)
+    mt = subset_mt(args.project_guid, mt, skip_sample_subset=args.skip_sample_subset,
+                   ignore_missing_samples=args.ignore_missing_samples,
+                   id_file=args.id_file)
 
     rows = annotate_fields(mt, args.gencode_release, args.gencode_path)
 

--- a/sv_pipeline/genome/load_data.py
+++ b/sv_pipeline/genome/load_data.py
@@ -205,7 +205,7 @@ def main():
     p.add_argument('--num-shards', type=int, default=1)
     p.add_argument('--block-size', type=int, default=2000)
     p.add_argument('--es-nodes-wan-only', action='store_true')
-    p.add_argument('--id-file', help='The full path (can start with gs://) of the id file.')
+    p.add_argument('--id-file', help='The full path (can start with gs://) of the id file. Should only be used for testing purposes, not intended for use in production')
 
     args = p.parse_args()
 

--- a/sv_pipeline/utils/common.py
+++ b/sv_pipeline/utils/common.py
@@ -10,7 +10,7 @@ CHROM_TO_XPOS_OFFSET = {chrom: (1 + i)*int(1e9) for i, chrom in enumerate(CHROMO
 GS_SAMPLE_PATH = 'gs://seqr-datasets/v02/GRCh38/RDG_{sample_type}_Broad_Internal/base/projects/{project_guid}/{project_guid}_{file_ext}'
 
 
-def _get_gs_samples(project_guid, file_ext, sample_type, expected_header):
+def _get_gs_samples(project_guid, file_ext, sample_type, expected_header, filename=None):
     """
     Get sample metadata from files in google cloud
 
@@ -20,7 +20,7 @@ def _get_gs_samples(project_guid, file_ext, sample_type, expected_header):
     :param expected_header: expected header to validate file
     :return: parsed data from the sample file as a list of lists
     """
-    file = GS_SAMPLE_PATH.format(project_guid=project_guid, sample_type=sample_type, file_ext=file_ext)
+    file = GS_SAMPLE_PATH.format(project_guid=project_guid, sample_type=sample_type, file_ext=file_ext) if not filename else filename
     process = subprocess.Popen(
         'gsutil cat {}'.format(file), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
     if process.wait() != 0:
@@ -32,7 +32,7 @@ def _get_gs_samples(project_guid, file_ext, sample_type, expected_header):
     return [line.decode('utf-8').strip().split('\t') for line in process.stdout]
 
 
-def get_sample_subset(project_guid, sample_type):
+def get_sample_subset(project_guid, sample_type, filename=None):
     """
     Get sample id subset for a given project
 
@@ -40,7 +40,7 @@ def get_sample_subset(project_guid, sample_type):
     :param sample_type: sample type (WES/WGS)
     :return: set of sample ids
     """
-    subset = _get_gs_samples(project_guid, file_ext='ids.txt', sample_type=sample_type, expected_header='s')
+    subset = _get_gs_samples(project_guid, file_ext='ids.txt', sample_type=sample_type, expected_header='s', filename=filename)
     if not subset:
         raise Exception('No sample subset file found')
     return {row[0] for row in subset}


### PR DESCRIPTION
The file name for the sample IDs is usually internally generated. But it is more convenient if it can also be provided with the command line argument. 