### PR TITLE
bump minimum required hail version

### DIFF
--- a/luigi_pipeline/requirements.txt
+++ b/luigi_pipeline/requirements.txt
@@ -1,4 +1,4 @@
 elasticsearch==7.9.1
-hail>=0.2.10
+hail>=0.2.77
 luigi==2.8.11
 google-api-python-client>=1.8.0


### PR DESCRIPTION
The requirements.txt is used to build a docker image for local seqr users to run this pipeline, and the pinned version of hail is pretty old and is now causing bugs (https://github.com/broadinstitute/seqr/issues/2460) 