### PR TITLE
Pin ES to 7.9.1

### DIFF
--- a/hail_scripts/elasticsearch/elasticsearch_client_v7.py
+++ b/hail_scripts/elasticsearch/elasticsearch_client_v7.py
@@ -9,7 +9,7 @@ try:
     import elasticsearch
 except ImportError:
     import os
-    os.system("pip install elasticsearch")
+    os.system("pip install elasticsearch==7.9.1")
     import elasticsearch
 
 


### PR DESCRIPTION
Our exports are failing because ES released a 8.0.0 python package which doesnt recognize port anymore. This pins us to 7.9.1 which is the same as our requirements file for local installs. Hail also only supports 6.X and 7.x for now.