### PR TITLE
Update contig recoding param for importing VCF to include Clinvar Mitochondrial variants

### DIFF
--- a/hail_scripts/utils/hail_utils.py
+++ b/hail_scripts/utils/hail_utils.py
@@ -60,6 +60,10 @@ def import_vcf(
     contig_recoding = {
         **{ref_contig.replace("chr", ""): ref_contig for ref_contig in ref.contigs if "chr" in ref_contig},
         **{f"chr{ref_contig}": ref_contig for ref_contig in ref.contigs if "chr" not in ref_contig}}
+    if genome_version == 38:
+        contig_recoding['MT'] = 'chrM'
+    else:
+        contig_recoding['chrM'] = 'MT'
 
     mt = hl.import_vcf(
         vcf_path,


### PR DESCRIPTION
Clinvar uses a slightly different contig name for the mitochondrial variants. It uses 'MT' instead of the 'M' in the GRCh38. That's why the mitochondrial variant data are missing in the downloaded Clinvar hail table. This PR adds an entry for `"MT": "chrM"` in the `contig_recoding` to include mitochondrial data.