### PR TITLE
Disable index for nested fields

### DIFF
--- a/hail_scripts/elasticsearch/elasticsearch_utils.py
+++ b/hail_scripts/elasticsearch/elasticsearch_utils.py
@@ -110,7 +110,7 @@ def elasticsearch_schema_for_table(table, disable_doc_values_for_fields=(), disa
                         % (es_field_name, properties)
                     )
             else:
-                if properties[es_field_name]["type"] == "neseted":
+                if "properties" in properties[es_field_name]["type"]:
                     nested_properties = properties[es_field_name]["properties"].copy()
                     for sub_field in nested_properties:
                         nested_properties[sub_field]["enabled"] = False

--- a/hail_scripts/elasticsearch/elasticsearch_utils.py
+++ b/hail_scripts/elasticsearch/elasticsearch_utils.py
@@ -100,11 +100,17 @@ def elasticsearch_schema_for_table(table, disable_doc_values_for_fields=(), disa
         logger.info("==> will disable index fields for %s", ", ".join(disable_index_for_fields))
         for es_field_name in disable_index_for_fields:
             if es_field_name not in properties:
-                raise ValueError(
-                    "'%s' in disable_index_for_fields arg is not in the elasticsearch schema: %s"
-                    % (es_field_name, properties)
-                )
-            properties[es_field_name]["index"] = False
+                flattened_fields = [key for key in properties if f"{es_field_name}_" in key]
+                if flattened_fields:
+                    for flattened_es_field_name in flattened_fields:
+                        properties[flattened_es_field_name]["index"] = False
+                else:
+                    raise ValueError(
+                        "'%s' in disable_index_for_fields arg is not in the elasticsearch schema: %s"
+                        % (es_field_name, properties)
+                    )
+            else:
+                properties[es_field_name]["index"] = False
 
     return properties
 

--- a/hail_scripts/elasticsearch/elasticsearch_utils.py
+++ b/hail_scripts/elasticsearch/elasticsearch_utils.py
@@ -98,7 +98,7 @@ def elasticsearch_schema_for_table(table, disable_doc_values_for_fields=(), disa
 
     if disable_index_for_fields:
         logger.info("==> will disable index fields for %s", ", ".join(disable_index_for_fields))
-        for es_field_name in disable_index_for_fields:
+        for es_field_name in disable_index_for_fields:               
             if es_field_name not in properties:
                 flattened_fields = [key for key in properties if key.startswith(f'{es_field_name}_')]
                 if flattened_fields:
@@ -110,9 +110,15 @@ def elasticsearch_schema_for_table(table, disable_doc_values_for_fields=(), disa
                         % (es_field_name, properties)
                     )
             else:
-                properties[es_field_name]["index"] = False
+                if properties[es_field_name]["type"] == "neseted":
+                    nested_properties = properties[es_field_name]["properties"].copy()
+                    for sub_field in nested_properties:
+                        nested_properties[sub_field]["enabled"] = False
+                    properties[es_field_name]["properties"] = nested_properties
+                else:
+                    properties[es_field_name]["index"] = False
 
-    return properties
+    return properties    
 
 def encode_field_name(s):
     """Encodes arbitrary string into an elasticsearch field name

--- a/hail_scripts/elasticsearch/elasticsearch_utils.py
+++ b/hail_scripts/elasticsearch/elasticsearch_utils.py
@@ -100,7 +100,7 @@ def elasticsearch_schema_for_table(table, disable_doc_values_for_fields=(), disa
         logger.info("==> will disable index fields for %s", ", ".join(disable_index_for_fields))
         for es_field_name in disable_index_for_fields:
             if es_field_name not in properties:
-                flattened_fields = [key for key in properties if f"{es_field_name}_" in key]
+                flattened_fields = [key for key in properties if key.startswith(f'{es_field_name}_')]
                 if flattened_fields:
                     for flattened_es_field_name in flattened_fields:
                         properties[flattened_es_field_name]["index"] = False

--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -226,11 +226,12 @@ class HailElasticSearchTask(luigi.Task):
     def import_mt(self):
         return hl.read_matrix_table(self.input()[0].path)
 
-    def export_table_to_elasticsearch(self, table, num_shards):
+    def export_table_to_elasticsearch(self, table, num_shards, disabled_fields=None):
         func_to_run_after_index_exists = None if not self.use_temp_loading_nodes else \
             lambda: self._es.route_index_to_temp_es_cluster(self.es_index)
         self._es.export_table_to_elasticsearch(table,
                                                index_name=self.es_index,
+                                               disable_index_for_fields=disabled_fields,
                                                func_to_run_after_index_exists=func_to_run_after_index_exists,
                                                elasticsearch_mapping_id="docId",
                                                num_shards=num_shards,

--- a/luigi_pipeline/lib/model/base_mt_schema.py
+++ b/luigi_pipeline/lib/model/base_mt_schema.py
@@ -16,9 +16,10 @@ class RowAnnotationFailed(Exception):
 
 
 class RowAnnotation:
-    def __init__(self, fn, name=None, requirements: List[str]=None):
+    def __init__(self, fn, name=None, disable_index=False, requirements: List[str]=None):
         self.fn = fn
         self.name = name or fn.__name__
+        self.disable_index=disable_index
         self.requirements = requirements
 
     def __repr__(self):
@@ -28,7 +29,7 @@ class RowAnnotation:
         return f"{self.name}{requires}"
 
 
-def row_annotation(name=None, fn_require=None):
+def row_annotation(name=None, disable_index=False, fn_require=None):
     """
     Function decorator for methods in a subclass of BaseMTSchema.
     Allows the function to be treated like an row_annotation with annotation name and value.
@@ -59,7 +60,7 @@ def row_annotation(name=None, fn_require=None):
                     raise ValueError('Schema: dependency %s is not a row annotation method.' % fn_require.__name__)
             requirements = [fn.name for fn in fn_requirements]
 
-        return RowAnnotation(func, name=name, requirements=requirements)
+        return RowAnnotation(func, name=name, disable_index=disable_index, requirements=requirements)
 
     return mt_prop_wrapper
 
@@ -210,3 +211,16 @@ class BaseMTSchema:
 
             select_fields.append(annotation.name)
         return self.mt.select_rows(*select_fields)
+
+    def get_disable_index_field(self):
+        '''
+        Retrieve the field indices that should be disabled
+        return: list of strings
+        '''
+        all_fields: List[RowAnnotation] = self.all_annotation_fns()
+        disabled_indices = []
+        for field in all_fields:
+            if field.disable_index == True:
+                disabled_indices += [field.name]
+  
+        return disabled_indices

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -49,25 +49,25 @@ class SeqrSchema(BaseMTSchema):
     def filters(self):
         return self.mt.filters
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def aIndex(self):
         return self.mt.a_index
     
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def wasSplit(self):
         return self.mt.was_split
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def originalAltAlleles(self):
         # TODO: This assumes we annotate `locus_old` in this code because `split_multi_hts` drops the proper `old_locus`.
         # If we can get it to not drop it, we should revert this to `old_locus`
         return variant_id.get_expr_for_variant_ids(self.mt.locus_old, self.mt.alleles_old)
 
-    @row_annotation(name='sortedTranscriptConsequences', fn_require=vep)
+    @row_annotation(name='sortedTranscriptConsequences', disable_index=True, fn_require=vep)
     def sorted_transcript_consequences(self):
         return vep.get_expr_for_vep_sorted_transcript_consequences_array(self.mt.vep)
 
-    @row_annotation(name='docId')
+    @row_annotation(name='docId', disable_index=True)
     def doc_id(self, length=512):
         return variant_id.get_expr_for_variant_id(self.mt, length)
 
@@ -75,27 +75,27 @@ class SeqrSchema(BaseMTSchema):
     def variant_id(self):
         return variant_id.get_expr_for_variant_id(self.mt)
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def contig(self):
         return variant_id.get_expr_for_contig(self.mt.locus)
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def pos(self):
         return variant_id.get_expr_for_start_pos(self.mt)
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def start(self):
         return variant_id.get_expr_for_start_pos(self.mt)
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def end(self):
         return variant_id.get_expr_for_end_pos(self.mt)
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def ref(self):
         return variant_id.get_expr_for_ref_allele(self.mt)
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def alt(self):
         return variant_id.get_expr_for_alt_allele(self.mt)
 
@@ -103,21 +103,21 @@ class SeqrSchema(BaseMTSchema):
     def xpos(self):
         return variant_id.get_expr_for_xpos(self.mt.locus)
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def xstart(self):
         return variant_id.get_expr_for_xpos(self.mt.locus)
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def xstop(self):
         return variant_id.get_expr_for_xpos(self.mt.locus) + hl.len(variant_id.get_expr_for_ref_allele(self.mt)) - 1
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def rg37_locus(self):
         if self.mt.locus.dtype.reference_genome.name != "GRCh38":
             raise RowAnnotationOmit
         return self.mt.rg37_locus
 
-    @row_annotation(fn_require=sorted_transcript_consequences)
+    @row_annotation(disable_index=True, fn_require=sorted_transcript_consequences)
     def domains(self):
         return vep.get_expr_for_vep_protein_domains_set_from_sorted(
             self.mt.sortedTranscriptConsequences)
@@ -126,11 +126,11 @@ class SeqrSchema(BaseMTSchema):
     def transcript_consequence_terms(self):
         return vep.get_expr_for_vep_consequence_terms_set(self.mt.sortedTranscriptConsequences)
 
-    @row_annotation(name='transcriptIds', fn_require=sorted_transcript_consequences)
+    @row_annotation(name='transcriptIds', disable_index=True, fn_require=sorted_transcript_consequences)
     def transcript_ids(self):
         return vep.get_expr_for_vep_transcript_ids_set(self.mt.sortedTranscriptConsequences)
 
-    @row_annotation(name='mainTranscript', fn_require=sorted_transcript_consequences)
+    @row_annotation(name='mainTranscript', disable_index=True, fn_require=sorted_transcript_consequences)
     def main_transcript(self):
         return vep.get_expr_for_worst_transcript_consequence_annotations_struct(
             self.mt.sortedTranscriptConsequences)
@@ -139,7 +139,7 @@ class SeqrSchema(BaseMTSchema):
     def gene_ids(self):
         return vep.get_expr_for_vep_gene_ids_set(self.mt.sortedTranscriptConsequences)
 
-    @row_annotation(name='codingGeneIds', fn_require=sorted_transcript_consequences)
+    @row_annotation(name='codingGeneIds', disable_index=True, fn_require=sorted_transcript_consequences)
     def coding_gene_ids(self):
         return vep.get_expr_for_vep_gene_ids_set(self.mt.sortedTranscriptConsequences, only_coding_genes=True)
 
@@ -151,7 +151,7 @@ class SeqrSchema(BaseMTSchema):
     def dbnsfp(self):
         return self._selected_ref_data.dbnsfp
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def geno2mp(self):
         return self._selected_ref_data.geno2mp
 
@@ -159,7 +159,7 @@ class SeqrSchema(BaseMTSchema):
     def gnomad_exomes(self):
         return self._selected_ref_data.gnomad_exomes
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def gnomad_exome_coverage(self):
         return self._selected_ref_data.gnomad_exome_coverage
 
@@ -167,7 +167,7 @@ class SeqrSchema(BaseMTSchema):
     def gnomad_genomes(self):
         return self._selected_ref_data.gnomad_genomes
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def gnomad_genome_coverage(self):
         return self._selected_ref_data.gnomad_genome_coverage
 
@@ -223,14 +223,14 @@ class SeqrVariantSchema(SeqrSchema):
     def af(self):
         return self.mt.info.AF[self.mt.a_index-1]
 
-    @row_annotation(name='AN')
+    @row_annotation(name='AN', disable_index=True)
     def an(self):
         return self.mt.info.AN
 
 
 class SeqrGenotypesSchema(BaseMTSchema):
 
-    @row_annotation()
+    @row_annotation(disable_index=True)
     def genotypes(self):
         return hl.agg.collect(hl.struct(**self._genotype_fields()))
 

--- a/luigi_pipeline/seqr_loading_optimized.py
+++ b/luigi_pipeline/seqr_loading_optimized.py
@@ -6,6 +6,8 @@ import re
 import luigi
 import hail as hl
 
+from collections import defaultdict
+
 from lib.hail_tasks import HailMatrixTableTask, HailElasticSearchTask, GCSorLocalTarget, MatrixTableSampleSetError
 from lib.model.seqr_mt_schema import SeqrSchema, SeqrVariantSchema, SeqrGenotypesSchema, SeqrVariantsAndGenotypesSchema
 import seqr_loading
@@ -62,7 +64,11 @@ class SeqrMTToESOptimizedTask(HailElasticSearchTask):
 
         row_ht = SeqrVariantsAndGenotypesSchema.elasticsearch_row(row_ht)
         es_shards = self._mt_num_shards(genotypes_mt)
-        self.export_table_to_elasticsearch(row_ht, es_shards)
+
+        # Initialize an empty SeqrVariantsAndGenotypesSchema to access class properties
+        disabled_fields = SeqrVariantsAndGenotypesSchema(None, ref_data=defaultdict(dict), clinvar_data=None).get_disable_index_field()
+        
+        self.export_table_to_elasticsearch(table=row_ht, num_shards=es_shards, disabled_fields=disabled_fields)
         
         self.cleanup(es_shards)
 


### PR DESCRIPTION
An attempt to disable index for nested fields such as `rg37_locus`, `sortedTranscriptConsequences`, and `genotypes`.