### PR TITLE
Rename _hom fields and remove Helix AC fields.

### DIFF
--- a/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
+++ b/download_and_create_reference_datasets/v02/hail_scripts/write_combined_reference_data_ht.py
@@ -173,7 +173,14 @@ CONFIG = {
     'gnomad_mito': {
         '38': {
             'path': 'gs://gcp-public-data--gnomad/release/3.1/ht/genomes/gnomad.genomes.v3.1.sites.chrM.ht',
-            'select': ['AN', 'AC_hom', 'AC_het', 'AF_hom', 'AF_het', 'max_hl']
+            'select': {
+                'AN': 'AN',
+                'AC': 'AC_hom',
+                'AC_het': 'AC_het',
+                'AF': 'AF_hom',
+                'AF_het': 'AF_het',
+                'max_hl': 'max_hl',
+            }
         }
     },
     'mitomap': {
@@ -198,9 +205,7 @@ CONFIG = {
         '38': {
             'path': 'gs://seqr-reference-data/GRCh38/mitochondrial/Helix/HelixMTdb_20200327.ht',
             'select': {
-                'AC_hom': 'counts_hom',
-                'AF_hom': 'AF_hom',
-                'AC_het': 'counts_het',
+                'AF': 'AF_hom',
                 'AF_het': 'AF_het',
                 'max_hl': 'max_ARF',
             }


### PR DESCRIPTION
This PR changes to the names of _hom fields under gnomad_mito and removes the helix AC fields. 