### PR TITLE
Stop exporting empty fields to ES.

### DIFF
--- a/luigi_pipeline/lib/hail_tasks.py
+++ b/luigi_pipeline/lib/hail_tasks.py
@@ -234,7 +234,7 @@ class HailElasticSearchTask(luigi.Task):
                                                func_to_run_after_index_exists=func_to_run_after_index_exists,
                                                elasticsearch_mapping_id="docId",
                                                num_shards=num_shards,
-                                               write_null_values=True)
+                                               )
 
     def cleanup(self, es_shards):
         self._es.route_index_off_temp_es_cluster(self.es_index)

--- a/luigi_pipeline/lib/model/seqr_mt_schema.py
+++ b/luigi_pipeline/lib/model/seqr_mt_schema.py
@@ -267,7 +267,8 @@ class SeqrGenotypesSchema(BaseMTSchema):
 
     def _genotype_filter_samples(self, filter):
         # Filter on the genotypes.
-        return hl.set(self.mt.genotypes.filter(filter).map(lambda g: g.sample_id))
+        samples = hl.set(self.mt.genotypes.filter(filter).map(lambda g: g.sample_id))
+        return hl.if_else(hl.len(samples) > 0, samples, hl.missing(hl.dtype('set<str>')))
 
     def _genotype_fields(self):
         # Convert the mt genotype entries into num_alt, gq, ab, dp, and sample_id.


### PR DESCRIPTION
This change may require some seqr code changes. One of the examples is as the following.
```
hit[SORTED_TRANSCRIPTS_FIELD_KEY] or []
```
Needs to be changed to:
```
hit.get(SORTED_TRANSCRIPTS_FIELD_KEY, [])
```